### PR TITLE
feat(ui): Add JWT to localStorage and auth-headers for HTTP requests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "@reach/router": "^1.3.4",
     "axios": "^0.20.0",
     "bootstrap": "^4.3.1",
+    "classnames": "^2.2.6",
     "gatsby": "^2.24.55",
     "gatsby-image": "^2.4.17",
     "gatsby-plugin-manifest": "^2.4.28",
@@ -20,12 +21,16 @@
     "gatsby-source-filesystem": "^2.3.28",
     "gatsby-transformer-sharp": "^2.2.12",
     "jquery": "^3.4.1",
+    "jwt-decode": "^3.0.0-beta.2",
     "node-sass": "^4.11.0",
     "prop-types": "^15.7.2",
     "react": "^16.9.0",
     "react-bootstrap": "^1.0.0-beta.8",
     "react-dom": "^16.9.0",
     "react-helmet": "^5.2.1",
+    "react-redux": "^7.2.1",
+    "redux": "^4.0.5",
+    "redux-thunk": "^2.3.0",
     "webpack": "^4.39.2"
   },
   "devDependencies": {
@@ -54,7 +59,7 @@
     "develop": "gatsby develop",
     "format": "pretty-quick --format",
     "heroku-postbuild": "gatsby build",
-    "lint": "eslint ./ --ext .js,.jsx",
+    "lint": "eslint ./ --ext .jsx",
     "lint-fix": "yarn lint --fix && pretty-quick",
     "start": "gatsby serve",
     "serve": "gatsby serve",
@@ -63,18 +68,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby-starter-photon"
-  },
-  "lint-staged": {
-    "*.{js,jsx}": [
-      "pretty-quick --staged",
-      "eslint ./ --fix",
-      "git add",
-      "eslint --fix"
-    ]
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
   }
 }

--- a/frontend/src/pages/portal.jsx
+++ b/frontend/src/pages/portal.jsx
@@ -1,19 +1,24 @@
 import React from 'react';
 import { Router } from '@reach/router';
 
+// Redux global state
+import { Provider } from 'react-redux';
+import store from '../redux/store';
+
 import Sample from './portal_pages/sample';
 import Register from './portal_pages/register';
 import Login from './portal_pages/login';
 
-// eslint-disable-next-line arrow-body-style
 const Portal = () => {
   return (
-    <Router basepath="/portal">
-      <Sample exact path="/sample" />
-      <Sample exact path="/sample/:resultsAmount" />
-      <Register exact path="/register" />
-      <Login exact path="/login" />
-    </Router>
+    <Provider store={store}>
+      <Router basepath="/portal">
+        <Sample exact path="/sample" />
+        <Sample exact path="/sample/:resultsAmount" />
+        <Register exact path="/register" />
+        <Login exact path="/login" />
+      </Router>
+    </Provider>
   );
 };
 

--- a/frontend/src/pages/portal_pages/login.jsx
+++ b/frontend/src/pages/portal_pages/login.jsx
@@ -8,6 +8,7 @@ class Login extends Component {
     this.state = {
       email: '',
       password: '',
+      errors: {},
     };
   }
 
@@ -31,6 +32,8 @@ class Login extends Component {
   }
 
   render() {
+    const { errors } = this.state;
+
     return (
       <section className={loginStyles.root}>
         <div className="container">
@@ -47,6 +50,7 @@ class Login extends Component {
                 placeholder="Enter email"
                 onChange={(event) => this.handleChange(event)}
                 value={this.state.email}
+                error={errors.email}
               />
             </div>
             <div className="form-group">
@@ -58,6 +62,7 @@ class Login extends Component {
                 placeholder="Enter password"
                 onChange={(event) => this.handleChange(event)}
                 value={this.state.password}
+                error={errors.password}
               />
             </div>
             <button type="submit" className="btn btn-warning">

--- a/frontend/src/pages/portal_pages/register.jsx
+++ b/frontend/src/pages/portal_pages/register.jsx
@@ -2,6 +2,12 @@ import React, { Component } from 'react';
 import axios from 'axios';
 import registerStyles from './register.module.scss';
 
+import {
+  MajorEnum,
+  PledgeClassEnum,
+  PositionEnum,
+} from '../../../../routes/api/util/enums/brother-enums';
+
 class Register extends Component {
   constructor() {
     super();
@@ -12,6 +18,7 @@ class Register extends Component {
       graduatingYear: 2020,
       pledgeClass: 'Alpha',
       position: 'Member',
+      errors: {},
     };
   }
 
@@ -21,6 +28,7 @@ class Register extends Component {
 
   handleSubmit(event) {
     event.preventDefault();
+
     const brotherData = {
       name: this.state.name,
       email: this.state.email,
@@ -39,13 +47,15 @@ class Register extends Component {
   }
 
   render() {
+    const { errors } = this.state;
+
     return (
       <section className={registerStyles.root}>
         <div className="container">
           <h1>
             <b>Register</b> a new brother
           </h1>
-          <form onSubmit={(event) => this.handleSubmit(event)}>
+          <form noValidate onSubmit={(event) => this.handleSubmit(event)}>
             <div className="form-group">
               <label htmlFor="name">Name</label>
               <input
@@ -55,6 +65,7 @@ class Register extends Component {
                 placeholder="Enter name"
                 onChange={(event) => this.handleChange(event)}
                 value={this.state.name}
+                error={errors.name}
               />
             </div>
             <div className="form-group">
@@ -66,6 +77,7 @@ class Register extends Component {
                 placeholder="Enter email"
                 onChange={(event) => this.handleChange(event)}
                 value={this.state.email}
+                error={errors.email}
               />
             </div>
             <div className="form-group">
@@ -75,18 +87,11 @@ class Register extends Component {
                 id="major"
                 onChange={(event) => this.handleChange(event)}
                 value={this.state.major}
+                error={errors.major}
               >
-                <option>Aerospace Engineering</option>
-                <option>Biomedical Engineering</option>
-                <option>Civil Engineering</option>
-                <option>Computer Engineering</option>
-                <option>Computer Science</option>
-                <option>Electrical Engineering</option>
-                <option>General Engineering</option>
-                <option>Industrial Engineering</option>
-                <option>Math</option>
-                <option>Mechanical Engineering</option>
-                <option>Software Engineering</option>
+                {Object.values(MajorEnum).map((major) => (
+                  <option key={major}>{major}</option>
+                ))}
               </select>
             </div>
             <div className="form-group">
@@ -98,6 +103,7 @@ class Register extends Component {
                 placeholder="Enter graduating year"
                 onChange={(event) => this.handleChange(event)}
                 value={this.state.graduatingYear}
+                error={errors.graduatingYear}
               />
             </div>
             <div className="form-group">
@@ -107,11 +113,11 @@ class Register extends Component {
                 id="pledgeClass"
                 onChange={(event) => this.handleChange(event)}
                 value={this.state.pledgeClass}
+                error={errors.pledgeClass}
               >
-                <option>Alpha</option>
-                <option>Beta</option>
-                <option>Gamma</option>
-                <option>Delta</option>
+                {Object.values(PledgeClassEnum).map((pledgeClass) => (
+                  <option key={pledgeClass}>{pledgeClass}</option>
+                ))}
               </select>
             </div>
             <div className="form-group">
@@ -121,9 +127,11 @@ class Register extends Component {
                 id="position"
                 onChange={(event) => this.handleChange(event)}
                 value={this.state.position}
+                error={errors.position}
               >
-                <option>Member</option>
-                <option>breh</option>
+                {Object.values(PositionEnum).map((position) => (
+                  <option key={position}>{position}</option>
+                ))}
               </select>
             </div>
             <button type="submit" className="btn btn-warning">

--- a/frontend/src/redux/actions/authActions.js
+++ b/frontend/src/redux/actions/authActions.js
@@ -1,0 +1,55 @@
+import axios from 'axios';
+import jwtDecode from 'jwt-decode';
+import setAuthToken from '../../util/setAuthToken';
+
+import { GET_ERRORS, SET_CURRENT_BROTHER } from './types';
+
+// Helper function
+const setCurrentUser = (decodedToken) => {
+  return {
+    type: SET_CURRENT_BROTHER,
+    payload: decodedToken,
+  };
+};
+
+// REGISTER Brother action
+const registerBrother = (brotherData) => (dispatch) => {
+  axios
+    .post('/api/brothers/register', brotherData)
+    .then((res) => res.status(200).send('Brother Registered!'))
+    .catch((error) =>
+      dispatch({
+        type: GET_ERRORS,
+        payload: error.response.data,
+      })
+    );
+};
+
+// LOGIN Brother action
+const loginBrother = (brotherData) => (dispatch) => {
+  axios
+    .post('/api/brothers/login', brotherData)
+    .then((res) => {
+      // Store token in localStorage, then as auth header in all axios requests
+      const { token } = res.data;
+      localStorage.setItem('authToken', token);
+      setAuthToken(token);
+
+      // Decode token to get user data in payload, then store in redux state
+      const decodedToken = jwtDecode(token);
+      dispatch(setCurrentUser(decodedToken));
+    })
+    .catch((error) =>
+      dispatch({ type: GET_ERRORS, payload: error.response.data })
+    );
+};
+
+// LOGOUT Brother action
+const logoutBrother = () => (dispatch) => {
+  // Remove JWT from localStorage, auth header, and clear current logged-in brother
+  localStorage.removeItem('authToken');
+  setAuthToken(false);
+  dispatch(setCurrentUser({}));
+};
+
+export { registerBrother, loginBrother, logoutBrother };

--- a/frontend/src/redux/actions/types.js
+++ b/frontend/src/redux/actions/types.js
@@ -1,0 +1,5 @@
+// Dispatched action type criteria
+const GET_ERRORS = 'GET_ERRORS';
+const SET_CURRENT_BROTHER = 'SET_CURRENT_BROTHER';
+
+export { GET_ERRORS, SET_CURRENT_BROTHER };

--- a/frontend/src/redux/reducers/authReducer.js
+++ b/frontend/src/redux/reducers/authReducer.js
@@ -1,0 +1,27 @@
+import { SET_CURRENT_BROTHER } from '../actions/types';
+
+const initialState = {
+  isAuthenticated: false,
+  user: {},
+  loading: false,
+};
+
+/**
+ * Returns whether or not an object is empty
+ */
+function isEmpty(object) {
+  return Object.keys(object).length === 0;
+}
+
+export default function (state = initialState, action) {
+  switch (action.type) {
+    case SET_CURRENT_BROTHER:
+      return {
+        ...state,
+        isAuthenticated: isEmpty(action.payload),
+        user: action.payload,
+      };
+    default:
+      return state;
+  }
+}

--- a/frontend/src/redux/reducers/errorReducer.js
+++ b/frontend/src/redux/reducers/errorReducer.js
@@ -1,0 +1,12 @@
+import { GET_ERRORS } from '../actions/types';
+
+const initialState = {};
+
+export default function (state = initialState, action) {
+  switch (action.type) {
+    case GET_ERRORS:
+      return action.payload;
+    default:
+      return state;
+  }
+}

--- a/frontend/src/redux/reducers/index.js
+++ b/frontend/src/redux/reducers/index.js
@@ -1,0 +1,8 @@
+import { combineReducers } from 'redux';
+import authReducer from './authReducer';
+import errorReducer from './errorReducer';
+
+export default combineReducers({
+  auth: authReducer,
+  errors: errorReducer,
+});

--- a/frontend/src/redux/store.js
+++ b/frontend/src/redux/store.js
@@ -1,0 +1,19 @@
+import { createStore, applyMiddleware, compose } from 'redux';
+import thunk from 'redux-thunk';
+import rootReducer from './reducers';
+
+const initialState = {};
+const middleware = thunk;
+
+// Creates a Redux store that holds the complete state tree of the app
+const store = createStore(
+  rootReducer,
+  initialState,
+  compose(
+    applyMiddleware(middleware),
+    // eslint-disable-next-line no-underscore-dangle
+    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+  )
+);
+
+export default store;

--- a/frontend/src/util/setAuthToken.js
+++ b/frontend/src/util/setAuthToken.js
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+const setAuthToken = (token) => {
+  // Apply authorization token to every request if logged in
+  if (token) {
+    axios.defaults.headers.common.Authorization = token;
+  }
+  // Logging a user out, delete the auth header
+  else {
+    delete axios.defaults.headers.common.Authorization;
+  }
+};
+
+export default setAuthToken;

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "main": "server.js",
   "scripts": {
     "dev:server": "nodemon server.js",
-    "dev:frontend": "cd frontend && gatsby develop",
+    "dev:frontend": "npm run develop --prefix frontend",
     "install-frontend": "npm install --prefix frontend",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "npm run lint:server && npm run lint:frontend",
     "lint:server": "eslint ./ --ext .js",
-    "lint:frontend": "cd frontend && eslint ./ --ext .jsx"
+    "lint:frontend": "npm run lint --prefix frontend"
   },
   "repository": {
     "type": "git",

--- a/routes/api/brothers/brothers.controller.js
+++ b/routes/api/brothers/brothers.controller.js
@@ -11,7 +11,7 @@ const validateLoginInput = require('../util/form-validation/login');
 
 /**
  * REGISTER Endpoint
- * @route POST api/brothers/
+ * @route POST api/brothers/register
  * @desc register a brother
  */
 brotherController.post('/register', (req, res) => {

--- a/routes/api/util/enums/brother-enums.js
+++ b/routes/api/util/enums/brother-enums.js
@@ -20,6 +20,7 @@ const PledgeClassEnum = Object.freeze({
 });
 
 const PositionEnum = Object.freeze({
+  Member: 'Member',
   Academic: 'Academic',
   Brotherhood: 'Brotherhood',
   CommunityService: 'Community Service',

--- a/routes/api/util/form-validation/register.js
+++ b/routes/api/util/form-validation/register.js
@@ -35,7 +35,7 @@ function validateRegisterInput(requestBody) {
     errors.name = 'Major field is required';
   }
   if (Validator.isEmpty(data.graduatingYear)) {
-    errors.graduateYear = 'Graduate year field is required';
+    errors.graduatingYear = 'Graduate year field is required';
   }
   if (Validator.isEmpty(data.pledgeClass)) {
     errors.pledgeClass = 'Pledge class field is required';

--- a/server.js
+++ b/server.js
@@ -23,7 +23,7 @@ mongoose
   })
   .then(() => console.log('MongoDB successfully connected...'))
   .catch((error) => {
-    throw new Error(`Error: ${error}`);
+    throw new Error(error);
   });
 
 // Passport config (JWT extraction from request headers)
@@ -34,7 +34,7 @@ require('./config/passport')(passport);
 const PORT = process.env.PORT || 5000;
 app.listen(PORT, (error) => {
   if (error) {
-    throw new Error(`Error: ${error}`);
+    throw new Error(error);
   }
   console.log(`Server started on port ${PORT}`);
 });


### PR DESCRIPTION
- Setup Redux on frontend for global state management
- _Why is Redux useful?_
  - When somebody logs in, the frontend will send its inputs to the server, which will validate them with stored credentials in MongoDB, then send back a JWT authorization token. On the frontend we will store this token in the browser like a cookie, so that whenever people come back to our site, they will still be logged in.
  - The token has information in it specifying the user's name and ID. We store this in redux global state so that in any component we can access the currently logged in user's name and ID. This is useful for displaying the name (such as navbar showing like `Welcome back, <name>`), or using their ID to make API calls (in the page that shows more details about a specific brother, we need to make an API call to `api/brothers/:id` to get the data)

Addresses #35