### PR TITLE
feat(ui): Hookup redux to register/login components

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,8 @@
     "react/no-unused-state": "warn",
     "jsx-a11y/label-has-associated-control": "off",
     "react/destructuring-assignment": "off",
-    "no-param-reassign": "off"
+    "no-param-reassign": "off",
+    "react/no-did-update-set-state": "off",
+    "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }]
   }
 }

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -3,7 +3,6 @@ import { Link as GatsbyLink } from 'gatsby';
 import Navbar from 'react-bootstrap/Navbar';
 import Nav from 'react-bootstrap/Nav';
 
-// eslint-disable-next-line arrow-body-style
 const NavBar = () => {
   return (
     <Navbar

--- a/frontend/src/pages/portal_pages/login.jsx
+++ b/frontend/src/pages/portal_pages/login.jsx
@@ -1,5 +1,9 @@
 import React, { Component } from 'react';
-import axios from 'axios';
+import { navigate } from '@reach/router';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { loginBrother } from '../../redux/actions/authActions';
 import loginStyles from './login.module.scss';
 
 class Login extends Component {
@@ -12,23 +16,34 @@ class Login extends Component {
     };
   }
 
+  componentDidUpdate(prevProps) {
+    // Redirect user to home page when logged in
+    if (
+      this.props.auth.isAuthenticated !== prevProps.auth.isAuthenticated &&
+      this.props.auth.isAuthenticated
+    ) {
+      navigate('/');
+    }
+    if (this.props.errors !== prevProps.errors && this.props.errors) {
+      this.setState({ errors: this.props.errors });
+    }
+  }
+
   handleChange(event) {
     this.setState({ [event.target.id]: event.target.value });
   }
 
   handleSubmit(event) {
     event.preventDefault();
+
+    // Create brother login data object
     const brotherData = {
       email: this.state.email,
       password: this.state.password,
     };
 
-    axios
-      .post('/api/brothers/login', brotherData)
-      .then((response) => console.log(response))
-      .catch((error) => {
-        throw new Error(`Error: ${error}`);
-      });
+    // Make API call and set global state
+    this.props.loginBrother(brotherData);
   }
 
   render() {
@@ -40,30 +55,42 @@ class Login extends Component {
           <h1>
             <b>Login</b> broski
           </h1>
-          <form onSubmit={(event) => this.handleSubmit(event)}>
+          <form noValidate onSubmit={(event) => this.handleSubmit(event)}>
             <div className="form-group">
               <label htmlFor="email">Email</label>
               <input
                 type="email"
-                className="form-control"
                 id="email"
                 placeholder="Enter email"
                 onChange={(event) => this.handleChange(event)}
                 value={this.state.email}
                 error={errors.email}
+                className={classnames('form-control', {
+                  'is-invalid': errors.email || errors.emailnotfound,
+                })}
               />
+              <span className="invalid-feedback">
+                {errors.email}
+                {errors.emailnotfound}
+              </span>
             </div>
             <div className="form-group">
               <label htmlFor="password">Password</label>
               <input
                 type="password"
-                className="form-control"
                 id="password"
                 placeholder="Enter password"
                 onChange={(event) => this.handleChange(event)}
                 value={this.state.password}
                 error={errors.password}
+                className={classnames('form-control', {
+                  'is-invalid': errors.password || errors.passwordincorrect,
+                })}
               />
+              <span className="invalid-feedback">
+                {errors.password}
+                {errors.passwordincorrect}
+              </span>
             </div>
             <button type="submit" className="btn btn-warning">
               Submit
@@ -75,4 +102,35 @@ class Login extends Component {
   }
 }
 
-export default Login;
+Login.propTypes = {
+  loginBrother: PropTypes.func.isRequired,
+  auth: PropTypes.shape({
+    isAuthenticated: PropTypes.bool,
+    user: PropTypes.shape({
+      id: PropTypes.string,
+      name: PropTypes.string,
+    }),
+  }),
+  errors: PropTypes.shape({
+    email: PropTypes.string,
+    emailnotfound: PropTypes.string,
+    password: PropTypes.string,
+    passwordincorrect: PropTypes.string,
+  }),
+  history: PropTypes.shape({
+    push: PropTypes.func,
+  }),
+};
+
+Login.defaultProps = {
+  auth: {},
+  errors: {},
+  history: {},
+};
+
+const mapStateToProps = (reduxState) => ({
+  auth: reduxState.auth,
+  errors: reduxState.errors,
+});
+
+export default connect(mapStateToProps, { loginBrother })(Login);

--- a/frontend/src/pages/portal_pages/register.jsx
+++ b/frontend/src/pages/portal_pages/register.jsx
@@ -1,5 +1,8 @@
 import React, { Component } from 'react';
-import axios from 'axios';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { registerBrother } from '../../redux/actions/authActions';
 import registerStyles from './register.module.scss';
 
 import {
@@ -22,6 +25,12 @@ class Register extends Component {
     };
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.errors !== prevProps.errors && this.props.errors) {
+      this.setState({ errors: this.props.errors });
+    }
+  }
+
   handleChange(event) {
     this.setState({ [event.target.id]: event.target.value });
   }
@@ -29,6 +38,7 @@ class Register extends Component {
   handleSubmit(event) {
     event.preventDefault();
 
+    // Create brother object
     const brotherData = {
       name: this.state.name,
       email: this.state.email,
@@ -38,12 +48,8 @@ class Register extends Component {
       position: this.state.position,
     };
 
-    axios
-      .post('/api/brothers/register', brotherData)
-      .then((response) => console.log(response))
-      .catch((error) => {
-        throw new Error(`Error: ${error}`);
-      });
+    // Make API call and set global state
+    this.props.registerBrother(brotherData);
   }
 
   render() {
@@ -60,79 +66,97 @@ class Register extends Component {
               <label htmlFor="name">Name</label>
               <input
                 type="text"
-                className="form-control"
                 id="name"
                 placeholder="Enter name"
                 onChange={(event) => this.handleChange(event)}
                 value={this.state.name}
                 error={errors.name}
+                className={classnames('form-control', {
+                  'is-invalid': errors.name,
+                })}
               />
+              <span className="invalid-feedback">{errors.name}</span>
             </div>
             <div className="form-group">
               <label htmlFor="email">Email address</label>
               <input
                 type="email"
-                className="form-control"
                 id="email"
                 placeholder="Enter email"
                 onChange={(event) => this.handleChange(event)}
                 value={this.state.email}
                 error={errors.email}
+                className={classnames('form-control', {
+                  'is-invalid': errors.email,
+                })}
               />
+              <span className="invalid-feedback">{errors.email}</span>
             </div>
             <div className="form-group">
               <label htmlFor="major">Major</label>
               <select
-                className="form-control"
                 id="major"
                 onChange={(event) => this.handleChange(event)}
                 value={this.state.major}
                 error={errors.major}
+                className={classnames('form-control', {
+                  'is-invalid': errors.major,
+                })}
               >
                 {Object.values(MajorEnum).map((major) => (
                   <option key={major}>{major}</option>
                 ))}
               </select>
+              <span className="invalid-feedback">{errors.major}</span>
             </div>
             <div className="form-group">
               <label htmlFor="name">Graduating year</label>
               <input
                 type="number"
-                className="form-control"
                 id="graduatingYear"
                 placeholder="Enter graduating year"
                 onChange={(event) => this.handleChange(event)}
                 value={this.state.graduatingYear}
                 error={errors.graduatingYear}
+                className={classnames('form-control', {
+                  'is-invalid': errors.graduatingYear,
+                })}
               />
+              <span className="invalid-feedback">{errors.graduatingYear}</span>
             </div>
             <div className="form-group">
               <label htmlFor="pledgeClass">Pledge class</label>
               <select
-                className="form-control"
                 id="pledgeClass"
                 onChange={(event) => this.handleChange(event)}
                 value={this.state.pledgeClass}
                 error={errors.pledgeClass}
+                className={classnames('form-control', {
+                  'is-invalid': errors.pledgeClass,
+                })}
               >
                 {Object.values(PledgeClassEnum).map((pledgeClass) => (
                   <option key={pledgeClass}>{pledgeClass}</option>
                 ))}
               </select>
+              <span className="invalid-feedback">{errors.pledgeClass}</span>
             </div>
             <div className="form-group">
               <label htmlFor="position">Position</label>
               <select
-                className="form-control"
                 id="position"
                 onChange={(event) => this.handleChange(event)}
                 value={this.state.position}
                 error={errors.position}
+                className={classnames('form-control', {
+                  'is-invalid': errors.position,
+                })}
               >
                 {Object.values(PositionEnum).map((position) => (
                   <option key={position}>{position}</option>
                 ))}
               </select>
+              <span className="invalid-feedback">{errors.position}</span>
             </div>
             <button type="submit" className="btn btn-warning">
               Submit
@@ -144,4 +168,33 @@ class Register extends Component {
   }
 }
 
-export default Register;
+Register.propTypes = {
+  registerBrother: PropTypes.func.isRequired,
+  auth: PropTypes.shape({
+    isAuthenticated: PropTypes.bool,
+    user: PropTypes.shape({
+      id: PropTypes.string,
+      name: PropTypes.string,
+    }),
+  }),
+  errors: PropTypes.shape({
+    name: PropTypes.string,
+    email: PropTypes.string,
+    major: PropTypes.string,
+    graduatingYear: PropTypes.number,
+    pledgeClass: PropTypes.string,
+    position: PropTypes.string,
+  }),
+};
+
+Register.defaultProps = {
+  auth: {},
+  errors: {},
+};
+
+const mapStateToProps = (reduxState) => ({
+  auth: reduxState.auth,
+  errors: reduxState.errors,
+});
+
+export default connect(mapStateToProps, { registerBrother })(Register);

--- a/frontend/src/redux/actions/authActions.js
+++ b/frontend/src/redux/actions/authActions.js
@@ -5,7 +5,7 @@ import setAuthToken from '../../util/setAuthToken';
 import { GET_ERRORS, SET_CURRENT_BROTHER } from './types';
 
 // Helper function
-const setCurrentUser = (decodedToken) => {
+export const setCurrentUser = (decodedToken) => {
   return {
     type: SET_CURRENT_BROTHER,
     payload: decodedToken,
@@ -13,25 +13,26 @@ const setCurrentUser = (decodedToken) => {
 };
 
 // REGISTER Brother action
-const registerBrother = (brotherData) => (dispatch) => {
+export const registerBrother = (brotherData) => (dispatch) => {
   axios
     .post('/api/brothers/register', brotherData)
-    .then((res) => res.status(200).send('Brother Registered!'))
-    .catch((error) =>
+    .then((response) => console.log(response))
+    .catch((error) => {
+      console.log(error);
       dispatch({
         type: GET_ERRORS,
         payload: error.response.data,
-      })
-    );
+      });
+    });
 };
 
 // LOGIN Brother action
-const loginBrother = (brotherData) => (dispatch) => {
+export const loginBrother = (brotherData) => (dispatch) => {
   axios
     .post('/api/brothers/login', brotherData)
-    .then((res) => {
+    .then((response) => {
       // Store token in localStorage, then as auth header in all axios requests
-      const { token } = res.data;
+      const { token } = response.data;
       localStorage.setItem('authToken', token);
       setAuthToken(token);
 
@@ -45,11 +46,9 @@ const loginBrother = (brotherData) => (dispatch) => {
 };
 
 // LOGOUT Brother action
-const logoutBrother = () => (dispatch) => {
+export const logoutBrother = () => (dispatch) => {
   // Remove JWT from localStorage, auth header, and clear current logged-in brother
   localStorage.removeItem('authToken');
   setAuthToken(false);
   dispatch(setCurrentUser({}));
 };
-
-export { registerBrother, loginBrother, logoutBrother };

--- a/frontend/src/redux/reducers/authReducer.js
+++ b/frontend/src/redux/reducers/authReducer.js
@@ -3,7 +3,6 @@ import { SET_CURRENT_BROTHER } from '../actions/types';
 const initialState = {
   isAuthenticated: false,
   user: {},
-  loading: false,
 };
 
 /**
@@ -18,7 +17,7 @@ export default function (state = initialState, action) {
     case SET_CURRENT_BROTHER:
       return {
         ...state,
-        isAuthenticated: isEmpty(action.payload),
+        isAuthenticated: !isEmpty(action.payload),
         user: action.payload,
       };
     default:

--- a/frontend/src/redux/store.js
+++ b/frontend/src/redux/store.js
@@ -3,16 +3,17 @@ import thunk from 'redux-thunk';
 import rootReducer from './reducers';
 
 const initialState = {};
-const middleware = thunk;
+const middleware = [thunk];
 
 // Creates a Redux store that holds the complete state tree of the app
 const store = createStore(
   rootReducer,
   initialState,
   compose(
-    applyMiddleware(middleware),
+    applyMiddleware(...middleware)
+    // Uncomment this if you want to use Redux devtools
     // eslint-disable-next-line no-underscore-dangle
-    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+    // window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
   )
 );
 

--- a/routes/api/util/form-validation/register.js
+++ b/routes/api/util/form-validation/register.js
@@ -9,6 +9,10 @@ function convertFieldsToString(requestBody) {
   const sanitizedData = requestBody;
   Object.keys(sanitizedData).forEach((key) => {
     sanitizedData[key] = !isEmpty(sanitizedData[key]) ? sanitizedData[key] : '';
+    // Casting number input to string
+    if (typeof sanitizedData[key] === 'number') {
+      sanitizedData[key] = String(sanitizedData[key]);
+    }
   });
   return sanitizedData;
 }
@@ -32,10 +36,12 @@ function validateRegisterInput(requestBody) {
     errors.email = 'Email field must be valid';
   }
   if (Validator.isEmpty(data.major)) {
-    errors.name = 'Major field is required';
+    errors.major = 'Major field is required';
   }
   if (Validator.isEmpty(data.graduatingYear)) {
     errors.graduatingYear = 'Graduate year field is required';
+  } else if (!Validator.isNumeric(data.graduatingYear)) {
+    errors.graduatingYear = 'Graduate year must be a number';
   }
   if (Validator.isEmpty(data.pledgeClass)) {
     errors.pledgeClass = 'Pledge class field is required';


### PR DESCRIPTION
- Connects Redux state management store to `Register` and `Login` components
  - Defines `propTypes` for each component, React makes us specify the types of the state we're getting from Redux
- Displays errors from `form-validation` under the inputs on `Register` and `Login` forms
  - Examples: <img width="1093" alt="Screen Shot 2020-09-20 at 3 24 01 PM" src="https://user-images.githubusercontent.com/42355738/93723815-c808ca80-fb56-11ea-8e84-488061f7c4c6.png">
![image](https://user-images.githubusercontent.com/42355738/93723826-d7881380-fb56-11ea-872d-2215ead9fc44.png)

## How to test this:
- Start the frontend and server
- Navigate to `http://localhost:8000/portal/register`, and put in your own credentials as a test
  - If you have empty inputs, it will display errors like the above picture
  - If you have valid inputs, view your browser's console and an object containing what was stored to the database should be logged like so:
  - ![image](https://user-images.githubusercontent.com/42355738/93723894-7d3b8280-fb57-11ea-8f37-f830f519fbcb.png)
- Next, navigate to `http://localhost:8000/portal/login`
  - The password for the registered account you just made would be the `pledgeClass` you chose connected with a dash `-` and the `graduatingYear` you chose. So for example if I chose `Beta` class and `2021` for graduation, the default password would be `Beta-2021`.
- If your credentials are correct, after logging in you will be redirected back to home page
- The idea is that webmaster committee registers pledges during the semester, and then we tell them to login to their account with these simple credentials. They will be able to change their password later on

